### PR TITLE
Fix MelonInfo showing incorrect version on launch.

### DIFF
--- a/AstralCore.cs
+++ b/AstralCore.cs
@@ -1,7 +1,7 @@
 ﻿using MelonLoader;
 using System;
 
-[assembly: MelonInfo(typeof(Astrum.AstralCore.Loader), nameof(Astrum.AstralCore), "0.8.0", downloadLink: "github.com/Astrum-Project/" + nameof(Astrum.AstralCore))]
+[assembly: MelonInfo(typeof(Astrum.AstralCore.Loader), nameof(Astrum.AstralCore), "0.8.1", downloadLink: "github.com/Astrum-Project/" + nameof(Astrum.AstralCore))]
 [assembly: MelonGame("VRChat", "VRChat")]
 [assembly: MelonColor(ConsoleColor.DarkMagenta)]
 


### PR DESCRIPTION
In the console on load, it displays the 0.8.1 release as 0.8.0, causing unnecessary confusion to users experiencing issues trying to troubleshoot their problems. This fixes that.

(If this were to get accepted, wouldn't that make it 0.8.2 though? Or just make it a fix and keep the release number the same.)